### PR TITLE
Bump postcss from 7.0.18 to 7.0.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8228,9 +8228,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",


### PR DESCRIPTION
- [ ] Bumps [postcss](https://github.com/postcss/postcss) from 7.0.18 to 7.0.36.

- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/7.0.18...7.0.36)

---
updated-dependencies:
- dependency-name: postcss dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>